### PR TITLE
Enable lazy loading for videos

### DIFF
--- a/surf.html
+++ b/surf.html
@@ -46,167 +46,167 @@
 
   <div class="grid">
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/lanormandina/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/lanormandina/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">BIOLOGIA</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/playagrande/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/playagrande/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">BIOLOGIA 2</div>
     </div>
     <div class="video-card">
-      <video src="https://video4.estadodelmar.com.ar/mobile/P.Grande/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video4.estadodelmar.com.ar/mobile/P.Grande/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">YACHT 1</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/yacht/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/yacht/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">YACHT 3</div>
     </div>
      <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/waikiki/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/waikiki/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">WAIKIKI</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/waikiki2/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/waikiki2/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">WAIKIKI</div>
     </div>
     <div class="video-card">
-    <video src="https://video.estadodelmar.com.ar/mobile/WAIKIKI3/index.m3u8" controls autoplay muted playsinline></video>
+    <video src="https://video.estadodelmar.com.ar/mobile/WAIKIKI3/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">WAIKIKI</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/balneario0/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/balneario0/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">EL 0</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/MARIANO/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/MARIANO/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">MARIANO</div>
     </div>
      <div class="video-card">
-      <video src="https://video4.estadodelmar.com.ar/mobile/BAHIA/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video4.estadodelmar.com.ar/mobile/BAHIA/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">LA BAHIA</div>
     </div>
      <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/HONUBEACH2/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/HONUBEACH2/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">HONU NORTE</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/honubeach/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/honubeach/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">HONU</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/maquinita/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/maquinita/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">LA MAQUINITA</div>
     </div>
     <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/horizonte/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/horizonte/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">HORIZONTE</div>
     </div>
     <div class="video-card">
-      <video src="https://video4.estadodelmar.com.ar/mobile/NATIVA/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video4.estadodelmar.com.ar/mobile/NATIVA/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">LA NATIVA</div>
     </div>
         <div class="video-card">
-    <video src="https://video4.estadodelmar.com.ar/mobile/Serena2/index.m3u8" controls autoplay muted playsinline></video>
+    <video src="https://video4.estadodelmar.com.ar/mobile/Serena2/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">SERENA</div>
     </div>
     <div class="video-card">
-      <video src="https://video4.estadodelmar.com.ar/mobile/SerenaSur/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video4.estadodelmar.com.ar/mobile/SerenaSur/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">SERENA SUR</div>
     </div>
     <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/puravida/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/puravida/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">PURA VIDA</div>
     </div>
     <div class="video-card">
-      <video src="https://video4.estadodelmar.com.ar/mobile/Acantilado/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video4.estadodelmar.com.ar/mobile/Acantilado/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">ACANTILADOS</div>
     </div>
     <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/lunaroja/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/lunaroja/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">LUNA ROJA</div>
     </div>
      <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/BRUSQUITAS/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/BRUSQUITAS/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">LAS BRUSQUITAS</div>
     </div>
      <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/HONORES/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/HONORES/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">HONORES MIRAMAR</div>
     </div>
     <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/miramar/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/miramar/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">HIJOS DEL MAR</div>
     </div>
      <div class="video-card">
-      <video src="https://video4.estadodelmar.com.ar/mobile/ALICANTE/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video4.estadodelmar.com.ar/mobile/ALICANTE/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">ALICANTE</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/SUNRIDER/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/SUNRIDER/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">SUNRIDER</div>
     </div>
     <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/elbarco/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/elbarco/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">EL BARCO</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/museomar2/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/museomar2/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">CARDIEL</div>
     </div>
         <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/PEPITA/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/PEPITA/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">LA PEPITA</div>
     </div>
     <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/hguerrero2/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/hguerrero2/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">EL MUELLE</div>
     </div>
     <div class="video-card">
-      <video src="https://video4.estadodelmar.com.ar/mobile/TORREON/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video4.estadodelmar.com.ar/mobile/TORREON/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">TORREON 1</div>
     </div>
     <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/torreon/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/torreon/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">TORREON 2</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/varese/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/varese/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">VARESE</div>
     </div>
     <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/varese2/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/varese2/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">EL CABO</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/laperla/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/laperla/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">LA PERLA</div>
     </div>
       <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/chapa/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/chapa/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">CHAPA 2</div>
     </div>
     <div class="video-card">
-      <video src="https://video4.estadodelmar.com.ar/mobile/CHAPADOMO/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video4.estadodelmar.com.ar/mobile/CHAPADOMO/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">CHAPA 4</div>
     </div>
     <div class="video-card">
-      <video src="https://video4.estadodelmar.com.ar/mobile/chapadmal5/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video4.estadodelmar.com.ar/mobile/chapadmal5/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">CHAPA 5</div>
     </div>
     <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/Santaclar2/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/Santaclar2/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">SANTA CLARA CHIRINGO</div>
     </div>
     <div class="video-card">
-      <video src="https://video2.estadodelmar.com.ar/mobile/CAMETNORTE/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video2.estadodelmar.com.ar/mobile/CAMETNORTE/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">SANTA CLARA CAMET NORTE</div>
     </div>
     <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/santaCl2/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/santaCl2/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">SANTA CLARA MARTINA 1</div>
     </div>
     <div class="video-card">
-      <video src="https://video.estadodelmar.com.ar/mobile/santaclara/index.m3u8" controls autoplay muted playsinline></video>
+      <video src="https://video.estadodelmar.com.ar/mobile/santaclara/index.m3u8" controls autoplay muted playsinline preload="none" loading="lazy"></video>
       <div class="video-title">SANTA CLARA MARTINA 2</div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- ensure `<video>` elements only download when near the viewport by disabling preload

## Testing
- `grep -n "loading=\"lazy\"" surf.html | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_6848832daca88322bea41bbfba8a16a0