### PR TITLE
Fix invalid textarea type

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
             </p>
             <p>
                 <label>
-                    <a id="sharing-link-anchor" href="">Link pa mi</a>: <textarea id="sharing-link-textbox" type="url" readonly="readonly"></textarea>
+                    <a id="sharing-link-anchor" href="">Link pa mi</a>: <textarea id="sharing-link-textbox" readonly="readonly"></textarea>
                 </label>
             </p>
         </main>


### PR DESCRIPTION
## Summary
- remove the invalid `type` attribute from the share link textarea

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68488344886c8322ac7447373b46909f